### PR TITLE
Fix the Webpack problem

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
  * Created by jazarja, 4ossiblellc on 9/20/16.
  */
 
-var merge = require('deepmerge');
+var merge = require('deepmerge').default;
 var _ = require('lodash');
 
 var isEmpty = function (map) {

--- a/index.js
+++ b/index.js
@@ -3,8 +3,13 @@
  * Created by jazarja, 4ossiblellc on 9/20/16.
  */
 
-var merge = require('deepmerge').default;
 var _ = require('lodash');
+var merge = require('deepmerge');
+
+// Webpack specific case
+if (typeof merge !== 'function') {
+  merge = merge.default
+}
 
 var isEmpty = function (map) {
   for(var key in map) {


### PR DESCRIPTION
This fixes the error that arises when `dynamodb-update-expression` is used with Webpack:

```
TypeError: merge is not a function
at Object.exports.generateUpdateExpression [as getUpdateExpression] (node_modules/dynamodb-update-expression/index.js:449:1)
```

Related:
https://github.com/TehShrike/deepmerge/issues/97#issuecomment-368603611

This is probably not the adequate solution but I would appreciate a cleaner way to solve this, all suggestions are more than welcome, thanks!