### PR TITLE
Fix issue #19

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A small library providing the solution to generate DynamoDB update expression by
 
 ## Release History
 
-* 0.1.22 Issue #19 parseInt considers alphaNumeric string as Numeric and passes the isNan check
+* 0.1.22 Issue #17, #19
 * 0.1.21 Issue #10 Boolean values changing from true to false are not getting set
 * 0.1.20 Issue #8 Remove colon characters from attribute names
 * 0.1.19 fix the error when options is defined or null

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A small library providing the solution to generate DynamoDB update expression by
 
 ## Release History
 
+* 0.1.22 Issue #19 parseInt considers alphaNumeric string as Numeric and passes the isNan check
 * 0.1.21 Issue #10 Boolean values changing from true to false are not getting set
 * 0.1.20 Issue #8 Remove colon characters from attribute names
 * 0.1.19 fix the error when options is defined or null

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamodb-update-expression",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "A small library providing the solution to return the update expression.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fix issue #17, #19 
- Special char '-' not allowed in ExpressionAttributeNames or Values
- parseInt considers alphaNumeric string as Numeric and passes the isNan check