### PR TITLE
added more special characters to remove list

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ var deepDiffMapper = function () {
 }();
 
 var removeSpecialChars = function (s) {
-  return s.replace(/\./g, "").replace(/:/g, "").replace(/#/g, "");
+  return s.replace(/\./g, "").replace(/:/g, "").replace(/#/g, "").replace(/\//g, "").replace(" ", "");
 };
 
 var removeSpecialCharsInExpression = function (s) {


### PR DESCRIPTION
I encountered two more instances of reserved characters in variable naming for replacement conditions. Maybe there's an exhaustive list provided by Amazon?